### PR TITLE
Pru monitor

### DIFF
--- a/hwp_gripper/control/gripper_server.py
+++ b/hwp_gripper/control/gripper_server.py
@@ -6,6 +6,8 @@ import multiprocessing
 import time
 import pickle as pkl
 import numpy as np
+from pru_monitor import PruMonitor
+from dataclasses import asdict
 
 this_dir = os.path.dirname(__file__)
 sys.path.append(this_dir)
@@ -36,6 +38,9 @@ class GripperServer(object):
         self.CTL = ct.Control(self.JXC)
         self.GPR = gp.Gripper(self.CTL)
         self.CMD = cg.Command(self.GPR)
+
+        self.pru_monitor = PruMonitor(self.pru_port)
+        self.pru_monitor.start()
 
         self.collector = col.GripperCollector(self.pru_port)
         self._run_collect_pru = multiprocessing.Value(ctypes.c_bool, False)
@@ -114,10 +119,8 @@ class GripperServer(object):
                     return_dict = self.move(command)
                 elif cmd == 'HOME':
                     return_dict = self.home()
-                elif cmd == 'LIMIT':
-                    return_dict = self.limit()
-                elif cmd == 'POSITION':
-                    return_dict = self.position()
+                elif cmd == 'GET_STATE':
+                    return_dict = self.get_state()
                 elif cmd == 'IS_COLD':
                     return_dict = self.is_cold_func(command)
                 elif cmd == 'FORCE':
@@ -130,17 +133,12 @@ class GripperServer(object):
     def move(self, command):
         args = command.split(' ')
         log = []
-        pru_chains = [2 * int(args[2]) - 2, 2 * int(args[2] -1)]
-        with self.encoder_direction.get_lock():
-            with self.encoder_edges_record.get_lock():
-                for chain in pru_chains:
-                    self.encoder_edges_record[chain] = 1
-                    if float(args[3]) >= 0:
-                        self.encoder_direction[chain] = 1
-                    elif float(args[3]) < 0:
-                        self.enocder_direction[chain] = -1
 
-        cur_pos = self._get_pos()[2 * int(args[2]) - 2]
+        actuator_idx = int(args[2]) - 1
+        state = self.pru_monitor.get_state()
+        act_state = state.actuator[actuator_idx]
+        cur_pos = act_state.pos
+
         warm_limit_pos = self.limit_pos[2 * int(args[2]) - 1]
         cold_limit_pos = self.limit_pos[2 * int(args[2]) - 2]
         if cur_pos + float(args[3]) > warm_limit_pos and not self.force and not self.is_cold:
@@ -162,24 +160,13 @@ class GripperServer(object):
         [log.append(line) for line in return_dict['log']]
         return_dict['log'] = log
 
-        with self.encoder_edges_record.get_lock():
-            for chain in pru_chains:
-                self.encoder_edges_record[chain] = 0
-
         return return_dict
 
     def home(self):
-        with self.encoder_edges_record.get_lock():
-            for index, _ in enumerate(self.encoder_edges_record):
-                self.encoder_edges_record[index] = 1
-
         return_dict = self.CMD.CMD('HOME')
 
-        with self.encoder_edges.get_lock():
-            with self.encoder_edges_record.get_lock():
-                for index, _ in enumerate(self.encoder_edges):
-                    self.encoder_edges_record[index] = 0
-                    self.encoder_edges[index] = 0
+        ## ADD CHECK HERE TO MAKE SURE JXC SETUP PIN TOGGLES!
+        self.pru_monitor.set_home()
 
         return return_dict
 
@@ -205,86 +192,41 @@ class GripperServer(object):
             self.force.value = bool(args[1])
 
         return {'result': True, 'log': log}
+    
+    def get_state(self):
+        state = self.pru_monitor.get_state()
+        return {'result': asdict(state)}
 
-    def limit(self):
-        log = []
-        log.append('Queried limit state')
-        return {'return': self.limit_state, 'log', log}
 
-    def position(self):
-        log = []
-        log.append('Queried position state')
-        return {'result': self._get_pos(), 'log': log}
+    def monitor_limit_state(self):
 
-    def collect_pru(self):
-        with self._run_collect_pru.get_lock():
-            self._run_collect_pru.value = True
-
-        while self._run_collect_pru:
+        emgs = [self.JXC.EMG1, self.JXC.EMG2, self.JXC.EMG3]
+        prev_state = self.pru_monitor.get_state()
+        while True:
+            time.sleep(0.2)
             # Collect data packets
-            self.collector.relay_gripper_data()
+            state = self.pru_monitor.get_state()
+            for i, act in enumerate(state.actuators):
+                prev_act = prev_state.actuators[i]
 
-            # Use collected data packets to find changes in gripper positions
-            encoder_data = self.collector.process_packets()
-            if len(encoder_data['state']):
-                edges = np.concatenate(([self.last_encoder ^ encoder_data['state'][0]],
-                                        encoder_data['state'][1:] ^ encoder_data['state'][:-1]))
+                # States haven't changed, don't do anything
+                if (act.cold_grip.state == prev_act.cold_grip.state \
+                    and act.warm_grip.state == prev_act.warm_grip.state):
+                    continue
 
-                with self.encoder_edges.get_lock():
-                    with self.encoder_direction.get_lock():
-                        with self.encoder_edges_record.get_lock():
-                            for index, pru in enumerate(self.encoder_pru):
-                                if self.encoder_edges_record[index]:
-                                    self.encoder_edges[index] += \
-                                        self.encoder_direction[index] * np.sum((edges >> pru) & 1)
+                # Else, we may need to take EMG action
+                print(f"Limit switch activation for axis {act.axis} at time: {time.time()}")
+                if act.cold_grip.state:
+                    print("Cold grip limit triggered, turning EMG Off")
+                    self.CMD.CMD(f'EMG OFF {act.axis}')
+                elif act.warm_grip.state and (not self.is_cold.value):
+                    print("Warm grip limit triggered while warm, turning EMG Off")
+                    self.CMD.CMD(f'EMG OFF {act.axis}')
+                else:
+                    print("Limits ok, turning EMG on")
+                    self.CMD.CMD(f'EMG ON {act.axis}')
 
-                self.last_encoder = encoder_data['state'][-1]
-
-            # Check if any of the limit switches have been triggered and prevent gripper movement if necessary
-            clock, state = self.collector.limit_state[0], int(self.collector.limit_state[1])
-
-            for index, pru in enumerate(self.limit_pru):
-                self.limit_state[index] = ((state & (1 << pru)) >> pru)
-
-            if (state and not self.is_cold.value) or self.limit_state[0] or self.limit_state[2] \
-                    or self.limit_state[4]:
-                self.last_limit_time = time.time()
-                if self.force.value and not self.is_forced:
-                    self.CMD.CMD('EMG ON')
-                elif self.last_limit != state and not self.force.value:
-                    self.last_limit = state
-
-                    if (self.limit_state[1] and not self.is_cold.value) or self.limit_state[0]:
-                        self.CMD.CMD('EMG OFF 1')
-                    else:
-                        self.CMD.CMD('EMG ON 1')
-
-                    if (self.limit_state[3] and not self.is_cold.value) or self.limit_state[2]:
-                        self.CMD.CMD('EMG OFF 2')
-                    else:
-                        self.CMD.CMD('EMG ON 2')
-
-                    if (self.limit_state[5] and not self.is_cold.value) or self.limit_state[4]:
-                        self.CMD.CMD('EMG OFF 3')
-                    else:
-                        self.CMD.CMD('EMG ON 3')
-
-                    print('Limit switch activation at clock: {}'.format(clock))
-                    for index, name in enumerate(self.limit_names):
-                        if self.limit_state[index]:
-                            print('{} activated'.format(name))
-            else:
-                if time.time() - self.last_limit_time > 5:
-                    if self.last_limit:
-                        self.CMD.CMD('EMG ON')
-                        self.last_limit = 0
-
-        with self._stopped.get_lock():
-            stopped.value = True
-
-    def _get_pos(self):
-        slope = 1 / 160.
-        return [rising_edges * slope for rising_edges in self.encoder_edges]
+            prev_state = state
 
     def __exit__(self):
         with self._run_collect_pru.get_lock():

--- a/hwp_gripper/control/pru_monitor.py
+++ b/hwp_gripper/control/pru_monitor.py
@@ -1,0 +1,258 @@
+"""
+
+The Beaglebone code periodically queries the status of six pins measuring the
+encoder signal and sends that data to this process in the form of UDP packets.
+Each actuator has two encoder signals
+
+Similarly the Beaglebone code also periodically queries the status of six pins
+hooked up to the warm and cold limit switches on each actuator and sends that
+data to the agent as seperate UDP packets
+
+Names of the encoder chains (currently the code does not use these, but it's still a
+good reference to know which index corresponds to which chain)
+self.encoder_names = ['Actuator 1 A', 'Actuator 1 B', 'Actuator 2 A',
+                      'Actuator 2 B', 'Actuator 3 A', 'Actuator 3 B']
+
+"""
+from dataclasses import dataclass, field, replace
+import numpy as np
+import socket
+import threading
+import struct
+import queue
+import time
+from typing import Optional, Tuple, Dict
+
+
+ENCODER_COUNTER_SIZE = 120
+NUM_ENCODERS = 6
+MM_PER_NOTCH = 160
+
+
+@dataclass
+class EncoderPacket:
+    """
+    Attributes
+    ------------
+    clock: np.ndarray
+        Encoder clock values
+    state: np.ndarray
+        Array of encoder states. Each state is an unsigned long, where the
+        2*i and (2*i + 1) bits are the state of the i-th quad encoders.
+    """
+    clock: np.ndarray
+    state: np.ndarray
+    timestamp: float = field(default_factory=time.time)
+
+    @classmethod
+    def from_data(cls, data):
+        unpack_str = 3*f"{ENCODER_COUNTER_SIZE}I"
+        x = struct.unpack(unpack_str, data)
+        clock = x[:ENCODER_COUNTER_SIZE]
+        # adds in the overflow bits
+        clock += x[ENCODER_COUNTER_SIZE : 2*ENCODER_COUNTER_SIZE]<<32
+
+        state_ints = x[2*ENCODER_COUNTER_SIZE : 3*ENCODER_COUNTER_SIZE]
+        return cls(clock=clock, state=state_ints)
+
+@dataclass
+class LimitPacket:
+    clock: int
+    state: int
+    timestamp: float = field(default_factory=time.time)
+
+    @classmethod
+    def from_data(cls, data):
+        x = struct.unpack("III", data)
+        clock = x[0] + (x[1]<<32)
+        return cls(clock=clock, state=x[2])
+
+@dataclass
+class ErrorPacket:
+    error_code: int
+    timestamp: float = field(default_factory=time.time)
+
+    @classmethod
+    def from_data(cls, data):
+        x = struct.unpack("I", data)
+        return cls(error_code=x[0])
+
+@dataclass
+class TimeoutPacket:
+    timeout_type: int
+    timestamp: float = field(default_factory=time.time)
+
+    @classmethod
+    def from_data(cls, data):
+        x = struct.unpack("I", data)
+        return cls(timeout_type=x[0])
+
+@dataclass
+class PulsePacket:
+    timestamp: float = field(default_factory=time.time)
+
+    @classmethod
+    def from_data(cls, data):
+        return cls()
+
+packet_headers = {
+    0xBAD0: EncoderPacket,
+    0xF00D: LimitPacket,
+    0x1234: ErrorPacket,
+    0x1234: TimeoutPacket,
+    0x1234: PulsePacket,
+}
+def parse_packet(data):
+    header = struct.unpack("H", data[:2])
+    if header not in packet_headers:
+        raise RuntimeError(f"Bad header: {header}")
+
+    packet_type = packet_headers[header]
+    return packet_type.from_data(data[2:])
+
+
+########################################
+# Gripper state definition
+########################################
+
+@dataclass
+class LimitState:
+    pru_bit: int
+    state: bool = False
+
+@dataclass
+class ActuatorState:
+    axis: int
+    limit_pru_bits: Tuple[int, int]
+
+    limits : Dict[str, LimitState] = {
+        'cold_grip': LimitState(pru_bit=limit_pru_bits[0]),
+        'warm_grip': LimitState(pru_bit=limit_pru_bits[1]),
+    }
+    pos: float = 0
+    calibrated: bool = False
+
+@dataclass
+class GripperState:
+    actuators : Tuple[ActuatorState, ActuatorState, ActuatorState] = (
+        ActuatorState(axis=1, limit_pru_bits=(8, 9)),
+        ActuatorState(axis=2, limit_pru_bits=(10, 11)),
+        ActuatorState(axis=3, limit_pru_bits=(12, 13)),
+    )
+
+    last_packet_received: float = 0.0
+    last_limit_received: float = 0.0
+    last_encoder_received: float = 0.0
+
+    _expiration_time: float = 10.0
+    _last_enc_state: Optional[int] = None
+
+    @property
+    def expired(self):
+        return time.time() - self.last_packet_received > self._expiration_time
+    
+    def update(self, packet):
+        self.last_packet_received = packet.timestamp
+
+        if isinstance(packet, EncoderPacket):
+            # Update the position of each encoder
+            for act in [self.act1, self.act2, self.act3]:
+                i = act.idx
+                a_state = (packet.state >> 2*i) & 1
+                b_state = (packet.state >> (2*i + 1)) & 1 
+
+                if self._last_enc_state is not None:
+                    rising_edges = np.diff(
+                        a_state, prepend=(self._last_enc_state >> 2*i) & 1
+                    ) == 1
+                    dirs = (b_state[rising_edges] * 2 - 1)
+                else:
+                    rising_edges = np.diff(a_state) == 1
+                    dirs = (b_state[1:][rising_edges] * 2 - 1)
+
+                act.pos += np.sum(dirs) * MM_PER_NOTCH
+
+            self._last_enc_state = packet.state[-1]
+
+        elif isinstance(packet, LimitPacket):
+            self.last_limit_received = packet.timestamp
+
+            # Update the limit state of each actuator
+            for limit in [self.cold_grip_1, self.warm_grip_1,
+                           self.cold_grip_2, self.warm_grip_2,
+                           self.cold_grip_3, self.warm_grip_3]:
+                limit.state = bool((packet.state >> limit.pru_bit) & 1)
+
+        elif isinstance(packet, ErrorPacket):
+            # Should we do anything else for errors?
+            print(f"Error packet received!! Error code: {packet.error_code}")
+
+        elif isinstance(packet, TimeoutPacket):
+            # Should we do anything else for timeouts?
+            print(f"Timeout packet received!! timeout type: {packet.timeout_type}")
+
+        else:
+            raise RuntimeError(f"Unknown packet type: {packet}")
+        
+        def set_home(self):
+            """
+            """
+            for act in self._gripper_state.actuators:
+                act.pos = 0
+                act.calibrated = True
+
+class PruMonitor:
+    """
+    This class monitors incoming UDP packets from the PRU, and uses incoming data to keep
+    track of the Gripper state.
+
+    Args
+    ------
+    port : int
+        Port to listen for incoming UDP packets
+    ip_address : str
+        IP Address to listen for incoming UDP packets. Defaults to using all available interfaces.
+    """
+    def __init__(self, port, ip_address=''):
+        self.port = port
+        self.ip_address = ip_address
+
+        self._gripper_state = GripperState()
+        self._state_lock = threading.Lock()
+
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.socket.bind((self.ip_address, self.port))
+        self.packet_queue = queue.Queue()
+
+        self.read_thread = threading.Thread(target=self._read_packets)
+        self.update_thread = threading.Thread(target=self._update_state)
+
+    def start(self):
+        self.read_thread.start()
+        self.update_thread.start()
+
+    def _read_packets(self):
+        while True:
+            data, _ = self.socket.recvfrom(1024)
+            self.packet_queue.put((parse_packet(data)))
+    
+    def _update_state(self):
+        while True:
+            packet = self.packet_queue.get()
+            with self._state_lock:
+                self._gripper_state.update(packet)
+    
+    def set_home():
+        """
+        Sets the current position as the home position
+        """
+        with self._state_lock:
+            self._gripper_state.set_home()
+            
+    
+    def get_state(self):
+        """
+        Gets the current gripper state
+        """
+        with self._state_lock:
+            return replace(self.gripper_state) # Return a copy of the state object


### PR DESCRIPTION
This PR moves everything that has to do with monitoring UDP packets, and determination of the actuator position and limit states to a standalone class, the `PruMonitor`. This monitors all encoders at all times to keep track of actuator positions without relying on user or OCS-agent input to the extent possible.

This can be run as a standalone process for testing, or is created by the `gripper_server`. I attempted to modify the `gripper_server` so that it uses the `pru_monitor` state instead of maintaining its own position/limit state estimations, however I think we may need to put a bit more thought into how we handle software limit-switch lockouts.

This has not yet been tested anywhere.

