### PR TITLE
Adds jxc monitor to state monitor class

### DIFF
--- a/hwp_gripper/control/gripper_server.py
+++ b/hwp_gripper/control/gripper_server.py
@@ -6,12 +6,12 @@ import multiprocessing
 import time
 import pickle as pkl
 import numpy as np
-from pru_monitor import PruMonitor, GripperState
 from dataclasses import asdict
 
 this_dir = os.path.dirname(__file__)
 sys.path.append(this_dir)
 
+from state_monitor import StateMonitor
 import BBB as bb
 import JXC831 as jx
 import control as ct
@@ -37,16 +37,8 @@ class GripperServer(object):
         self.GPR = gp.Gripper(self.CTL)
         self.CMD = cg.Command(self.GPR)
 
-        self._gripper_queue = multiprocessing.Queue()
-        self._gripper_queue.put(GripperState())
-
-        self.pru_monitor = PruMonitor(self.pru_port, self._gripper_queue)
-        print('Starting PRU Monitor')
-        self.pru_monitor.start()
-
-        self.jxc_process = multiprocessing.Process(target = self.jxc_monitor, daemon = True)
-        print('Starting JXC Monitor')
-        self.jxc_process.start()
+        self.state_monitor = StateMonitor(self.pru_port, jxc=self.JXC)
+        self.state_monitor.start()
 
         self.limit_pos = [13.,10.,13.,10.,13.,10.]
 
@@ -96,7 +88,7 @@ class GripperServer(object):
         log = []
 
         actuator_idx = int(args[2]) - 1
-        state = self.pru_monitor.get_state()
+        state = self.state_monitor.get_state()
         act_state = state.actuator[actuator_idx]
         cur_pos = act_state.pos
 
@@ -126,11 +118,6 @@ class GripperServer(object):
 
     def home(self):
         return_dict = self.CMD.CMD('HOME')
-
-        # Returns True if JXC SETUP pin toggles
-        if return_dict['result']:
-            self.pru_monitor.set_home()
-
         return return_dict
 
     def is_cold_func(self, command):
@@ -155,31 +142,14 @@ class GripperServer(object):
     
     def get_state(self):
         log = []
-        state = self.pru_monitor.get_state()
+        state = self.state_monitor.get_state()
         log.append('Query actuator state')
         return {'result': asdict(state), 'log': log}
-
-    def jxc_monitor(self):
-        controller_bits = ['SETUP', 'SVON', 'BUSY', 'SETON', 'INP', 'SVRE', 'ALARM']
-        actuator_bits = [word+num for word in ['BRAKE', 'EMG'] for num in ['1','2','3']]
-        while True:
-            time.sleep(1)
-            return_dict = self.CMD.CMD('STATUS')            
-            gripper_state = self._gripper_queue.get()
-            for line in return_dict['log']:
-                info = line.split(' ')
-                if info[0] in controller_bits:
-                    exec('gripper_state.%s = bool(int(%s))' % (info[0],info[-1]))
-                elif info[0] in actuator_bits:
-                    axis = int(info[0][-1])
-                    exec('gripper_state.actuators[%i].%s = bool(int(%s))' %
-                         (axis-1,info[0][:-1],info[-1]))
-            self._gripper_queue.put(gripper_state)
 
     def limit_monitor(self):
         prev_force = self.force.value
         prev_is_cold = self.is_cold.value
-        prev_state = self.pru_monitor.get_state()
+        prev_state = self.state_monitor.get_state()
 
         start = True
         while True:
@@ -187,7 +157,7 @@ class GripperServer(object):
             # Collect data packets
             force = self.force.value
             is_cold = self.is_cold.value
-            state = self.pru_monitor.get_state()
+            state = self.state_monitor.get_state()
             for i, act in enumerate(state.actuators):
                 prev_act = prev_state.actuators[i]
                 # States haven't changed, don't do anything

--- a/hwp_gripper/control/state_monitor.py
+++ b/hwp_gripper/control/state_monitor.py
@@ -18,7 +18,8 @@ self.limit_names = ['Actuator 1 Cold', 'Actuator 1 Warm', 'Actuator 2 Cold',
                     'Actuator 2 Warm', 'Actuator 3 Cold', 'Actuator 3 Warm']
 
 """
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
+from copy import deepcopy
 import numpy as np
 import socket
 import struct
@@ -30,6 +31,22 @@ import queue
 
 ENCODER_COUNTER_SIZE = 120
 MM_PER_NOTCH = 1./160
+
+
+@dataclass
+class JXCPacket:
+    """Packet that contains update to JXC pins"""
+    setup: bool = False
+    svon: bool = False
+    busy: bool = False
+    seton: bool = False
+    inp: bool = False
+    svre: bool = False
+    alarm: bool = False
+    brake: Tuple[bool, bool, bool] = (False, False, False)
+    emg: Tuple[bool, bool, bool] = (False, False, False)
+    out: int = 0
+    timestamp: float = field(default_factory=time.time)
 
 
 @dataclass
@@ -153,10 +170,9 @@ class ActuatorState:
     limits: Optional[Dict[str, LimitState]] = None
 
     pos: float = 0
-    calibrated: bool = False
 
-    BRAKE: bool = True
-    EMG: bool = False
+    brake: bool = True
+    emg: bool = False
 
     def __post_init__(self):
         self.limits = {
@@ -164,6 +180,42 @@ class ActuatorState:
             'warm_grip': LimitState(pru_bit=self.limit_pru_bits[1]),
         }
 
+@dataclass
+class JXCState:
+    setup: bool = False
+    svon: bool = False
+    busy: bool = False
+    seton: bool = False
+    inp: bool = False
+    svre: bool = False
+    alarm: bool = False
+    out: int = 0
+
+    @property
+    def status(self):
+        """
+        Current status of the controller determined from JXC input pins.
+        Described on page 43 of the JXC manual: 
+            https://www.smcworld.com/assets/manual/en-jp/files/SFOD-OMT0010.pdf
+        """
+
+        # Bit string that we can use to easily check current state
+        status_bits = [self.busy, self.inp, self.svre, self.seton]
+        bit_rep = "".join([str(s) for s in status_bits])
+
+        if self.out == 0:
+            if bit_rep == "0000":
+                return 'powered_down_servo_off'
+            elif bit_rep == "0010":
+                return 'powered_down_servo_on'
+            elif bit_rep == "0100":
+                return 'return_to_origin'
+            elif bit_rep == "0111":
+                return 'home'
+        else:
+            # This contains a number of different cases, but from the docs they
+            # don't seem to be 1-to-1 to bit_rep
+            return f'output_step_{self.out}'
 
 @dataclass
 class GripperState:
@@ -172,21 +224,18 @@ class GripperState:
         ActuatorState(axis=2, limit_pru_bits=(10, 11)),
         ActuatorState(axis=3, limit_pru_bits=(12, 13)),
     )
+    jxc = JXCState()
 
     last_packet_received: float = 0.0
     last_limit_received: float = 0.0
     last_encoder_received: float = 0.0
 
-    SETUP: bool = False
-    SVON: bool = False
-    BUSY: bool = False
-    SETON: bool = False
-    INP: bool = False
-    SVRE: bool = False
-    ALARM: bool = False
+    calibrated: bool = False
+    calibrated_at: float = 0
 
     _expiration_time: float = 10.0
     _last_enc_state: Optional[int] = None
+    _left_home: bool = False
 
     @property
     def expired(self):
@@ -197,6 +246,29 @@ class GripperState:
         """Updates the gripper state based on an incoming PRU packet"""
         self.last_packet_received = packet.timestamp
 
+        if isinstance(packet, JXCPacket):
+            self.jxc.setup = packet.setup
+            self.jxc.svon = packet.svon
+            self.jxc.busy = packet.busy
+            self.jxc.seton = packet.seton
+            self.jxc.inp = packet.inp
+            self.jxc.svre = packet.svre
+            self.jxc.alarm = packet.alarm
+            for i, act in self.actuators:
+                act.brake = packet.brake[i]
+                act.emg = packet.emg[i]
+            
+            if self._left_home:
+                if self.jxc.status == 'home':
+                    for act in self.actuators:
+                        act.pos = 0
+                    self.calibrated = True
+                    self.calibrated_at = time.time()
+                    self._left_home = False
+
+            if self.jxc.out != 0:
+                self._left_home = True
+            
         if isinstance(packet, EncoderPacket):
             # Update the position of each encoder
             for act in self.actuators:
@@ -238,13 +310,8 @@ class GripperState:
         else:
             raise RuntimeError(f"Unknown packet type: {packet}")
 
-    def set_home(self):
-        for act in self.actuators:
-            act.pos = 0
-            act.calibrated = True
 
-
-class PruMonitor:
+class StateMonitor:
     """
     This class monitors incoming UDP packets from the PRU, and uses incoming
     data to keep track of the Gripper state.
@@ -258,46 +325,73 @@ class PruMonitor:
         available interfaces.
     """
 
-    def __init__(self, port, gripper_queue, ip_address=''):
+    def __init__(self, port, jxc=None, ip_address='', jxc_sample_time=0.5):
         self.port = port
         self.ip_address = ip_address
 
-        self._gripper_queue = gripper_queue
+        self._gripper_state = GripperState()
         self._state_lock = threading.Lock()
+        self.jxc = jxc
+        self.jxc_sample_time = jxc_sample_time
 
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.socket.bind((self.ip_address, self.port))
         self.packet_queue = queue.Queue()
 
-        self.read_thread = threading.Thread(target=self._read_packets, daemon=True)
-        self.update_thread = threading.Thread(target=self._update_state, args=(self._gripper_queue,),
-                                              daemon=True)
+        self.monitor_pru_thread = threading.Thread(target=self._monitor_pru, daemon=True)
+        self.update_thread = threading.Thread(target=self._update_state, daemon=True)
+        self.monitor_jxc_thread = threading.Thread(target=self._monitor_jxc, daemon=True)
 
     def start(self):
-        self.read_thread.start()
+        """Start threads"""
+        print("Starting state monitor threads")
         self.update_thread.start()
+        self.monitor_pru_thread.start()
+        self.monitor_jxc_thread.start()
 
-    def _read_packets(self):
+    def _monitor_pru(self):
         while True:
             data, _ = self.socket.recvfrom(2048)
             self.packet_queue.put((parse_packet(data)))
 
-    def _update_state(self, gripper_queue):
+    def _update_state(self):
         while True:
             packet = self.packet_queue.get()
             with self._state_lock:
-                _gripper_state = gripper_queue.get()
-                _gripper_state.update(packet)
-                gripper_queue.put(_gripper_state)
+                self._gripper_state.update(packet)
 
-    def set_home(self):
-        """
-        Sets the current position as the home position
-        """
-        with self._state_lock:
-            _gripper_state = self._gripper_queue.get()
-            _gripper_state.set_home()
-            self._gripper_queue.put(_gripper_state)
+    def _monitor_jxc(self):
+        if self.jxc is None:
+            return
+
+        jxc_mapping = {
+            'setup': self.jxc.SETUP,
+            'svon': self.jxc.SVON,
+            'busy': self.jxc.BUSY,
+            'seton': self.jxc.SETON,
+            'inp': self.jxc.INP,
+            'svre': self.jxc.SVRE,
+            'alarm': self.jxc.ALARM,
+            'brake': [self.jxc.BRAKE1, self.jxc.BRAKE2, self.jxc.BRAKE3],
+            'emg': [self.jxc.EMG1, self.jxc.EMG2, self.jxc.EMG3],
+            'out': [getattr(self.jxc, f'OUT{i}') for i in range(1, 9)],
+        }
+
+        while True:
+            d = {}
+            for k, v in jxc_mapping.items():
+                if k in ['brake', 'emg']:
+                    d[k] = (self.jxc.read(vv) for vv in v)
+                elif k == 'out':
+                    bin_arr = [self.jxc.read(vv) for vv in v]
+                    # Converts a list of 1s and 0s representing a bin number
+                    # to an int
+                    d[k] = int(map(str, bin_arr), 2) 
+                else:
+                    d[k] = self.jxc.read(v)
+            
+            self.packet_queue.put(JXCPacket(**d))
+            time.sleep(self.jxc_sample_time)
 
     def get_state(self):
         """
@@ -305,7 +399,4 @@ class PruMonitor:
         """
         with self._state_lock:
             # Return a copy of the state object
-            _gripper_state = self._gripper_queue.get()
-            return_state = replace(_gripper_state)
-            self._gripper_queue.put(_gripper_state)
-            return return_state
+            return deepcopy(self._gripper_state)


### PR DESCRIPTION
This takes some changes @bbixler500 made and makes them compatible with the PRU_monitor process that was monitoring the gripper state. What was called the PRU_monitor was renamed to "StateMonitor" since it's now monitoring pru and jxc info.